### PR TITLE
Fix PerfectFluidMatter init for None eos_params

### DIFF
--- a/main.py
+++ b/main.py
@@ -897,11 +897,11 @@ class PerfectFluidMatter(MatterModel):
         # Equation of state parameters
         if eos_type == "linear":
             # p = w * ρ
-            self.w = nn.Parameter(torch.tensor(eos_params.get("w", 0.0)))
+            self.w = nn.Parameter(torch.tensor(self.eos_params.get("w", 0.0)))
         elif eos_type == "polytropic":
             # p = K * ρ^Γ
-            self.K = nn.Parameter(torch.tensor(eos_params.get("K", 1.0)))
-            self.Gamma = nn.Parameter(torch.tensor(eos_params.get("Gamma", 5/3)))
+            self.K = nn.Parameter(torch.tensor(self.eos_params.get("K", 1.0)))
+            self.Gamma = nn.Parameter(torch.tensor(self.eos_params.get("Gamma", 5/3)))
     
     def equation_of_state(self, density: torch.Tensor) -> torch.Tensor:
         if self.eos_type == "linear":


### PR DESCRIPTION
## Summary
- fix `PerfectFluidMatter` so it can be instantiated without passing `eos_params`

## Testing
- `pip install torch` *(fails: operation cancelled due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6862b49486808320a5bf1072359cec4f